### PR TITLE
update go.mod

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"log"
 
-	"falcon-go/falcon" // Using local module path
+	"github.com/zhenfeizhang/falcon-go/falcon" // Using local module path
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module falcon-go
+module github.com/zhenfeizhang/falcon-go
 
 go 1.21


### PR DESCRIPTION
```
> go mod tidy
go: finding module for package github.com/zhenfeizhang/falcon-go/falcon
go: found github.com/zhenfeizhang/falcon-go/falcon in github.com/zhenfeizhang/falcon-go v0.0.0-20250213143230-8ae42f4142cd
go: github.com/ethereum/go-ethereum/core/types imports
        github.com/zhenfeizhang/falcon-go/falcon: github.com/zhenfeizhang/falcon-go@v0.0.0-20250213143230-8ae42f4142cd: parsing go.mod:
        module declares its path as: falcon-go
                but was required as: github.com/zhenfeizhang/falcon-go
```